### PR TITLE
Variable Define and Bug fix

### DIFF
--- a/src/editor.ts
+++ b/src/editor.ts
@@ -81,7 +81,7 @@ class CalctexHintRenderer implements PluginValue {
               digitGroupSeparator : CalctexPlugin.INSTANCE.settings.groupSeparator,
               fractionalDigits: (isApproximation && CalctexPlugin.INSTANCE.settings.approxDecimalPrecision !== -1 ) 
                 ? CalctexPlugin.INSTANCE.settings.approxDecimalPrecision
-                : "auto" as 'auto',
+                : "max" as 'max',
             };
 
             const formattedFormula = formula.replace("\\\\", "").replace("&", "");
@@ -91,18 +91,16 @@ class CalctexHintRenderer implements PluginValue {
             for (const previousLine of previousLatexLines) {
               try {
                 // Remove the last line break and align sign
-                const formattedPreviousLine = previousLine.replace("\\\\", "").replace("&", "");
-                const lineExpression = calculationEngine.parse(formattedPreviousLine).simplify();
+                const formattedPreviousLine = previousLine
+                  .replace('\\\\', '')
+                  .replace('&', '');
 
-                const lineExpressionParts = lineExpression.latex.split("=");
-                if (lineExpressionParts.length <= 1) continue; 
+                if (formattedPreviousLine.indexOf(':=') === -1) continue;
 
-                  const jsonValue = calculationEngine.parse(lineExpressionParts[lineExpressionParts.length - 1].trim()).json;
-  
-                  expression = expression.subs({
-                    [lineExpressionParts[0].trim()]: jsonValue,
-                  });
-              } catch (e) { console.error(e); }
+                calculationEngine.parse(formattedPreviousLine).evaluate();
+              } catch (e) {
+                console.error(e);
+              }
             }
 
             // Calculate the expression

--- a/src/editor.ts
+++ b/src/editor.ts
@@ -85,7 +85,6 @@ class CalctexHintRenderer implements PluginValue {
             };
 
             const formattedFormula = formula.replace("\\\\", "").replace("&", "");
-            let expression = calculationEngine.parse(formattedFormula);
 
             // Add variables from previous lines
             for (const previousLine of previousLatexLines) {
@@ -102,6 +101,8 @@ class CalctexHintRenderer implements PluginValue {
                 console.error(e);
               }
             }
+						
+            let expression = calculationEngine.parse(formattedFormula);
 
             // Calculate the expression
             let result = null;


### PR DESCRIPTION
# Added Features

You can now define variable and function by `:=` expression

ex)
```
\begin{align}
x := 5 \\
f(x) := x^2 \\
f(x) = 25
\end{align}
```

# Fix Bug

#17 : `fractionalDigits: 'auto'` makes that bug.

# P.S

I'm planning to add `.solve()` method. after midterm exam.
and can i add `prettier` at this project?